### PR TITLE
refactor:DEV-29 #comment JACKSON config(localtime 직렬화 몽고DB 등에 필요), RestTe…

### DIFF
--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/common/config/RestTemplateConfig.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/common/config/RestTemplateConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
@@ -44,7 +45,7 @@ public class RestTemplateConfig {
     }
 
     MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
-    converter.setObjectMapper(objectMapper());
+    converter.setObjectMapper(restTemplateObjectMapper());
     converter.setSupportedMediaTypes(
         Arrays.asList(
             MediaType.APPLICATION_JSON,
@@ -56,7 +57,7 @@ public class RestTemplateConfig {
   }
 
   @Bean
-  public ObjectMapper objectMapper() {
+  @Qualifier("restTemplateObjectMapper") public ObjectMapper restTemplateObjectMapper() {
     return new ObjectMapper();
   }
 }

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/chat/command/domain/aggregate/UserMoodHistory.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/chat/command/domain/aggregate/UserMoodHistory.java
@@ -3,6 +3,8 @@ package com.deveagles.be15_deveagles_be.features.chat.command.domain.aggregate;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -32,7 +34,13 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 public class UserMoodHistory {
 
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final ObjectMapper objectMapper;
+
+  static {
+    objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
+    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+  }
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/chat/command/infrastructure/adapters/HuggingFaceApiAdapter.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/chat/command/infrastructure/adapters/HuggingFaceApiAdapter.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -44,7 +45,8 @@ public class HuggingFaceApiAdapter {
   private int apiTimeoutMs;
 
   @Autowired
-  public HuggingFaceApiAdapter(RestTemplate restTemplate, ObjectMapper objectMapper) {
+  public HuggingFaceApiAdapter(
+      RestTemplate restTemplate, @Qualifier("restTemplateObjectMapper") ObjectMapper objectMapper) {
     this.restTemplate = configureRestTemplate(restTemplate, objectMapper);
     this.objectMapper = objectMapper;
     this.requestBuilder = new HuggingFaceRequestBuilder();

--- a/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/chat/command/infrastructure/adapters/GeminiApiAdapterIntegrationTest.java
+++ b/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/chat/command/infrastructure/adapters/GeminiApiAdapterIntegrationTest.java
@@ -4,13 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.deveagles.be15_deveagles_be.features.chat.command.infrastructure.adapters.GeminiApiAdapter.GeminiTextResponse;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 /** Gemini API 실제 연결 통합 테스트 */
-// @Disabled
+@Disabled
 @SpringBootTest
 public class GeminiApiAdapterIntegrationTest {
 

--- a/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/chat/command/infrastructure/adapters/HuggingFaceApiAdapterIntegrationTest.java
+++ b/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/chat/command/infrastructure/adapters/HuggingFaceApiAdapterIntegrationTest.java
@@ -5,13 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.deveagles.be15_deveagles_be.features.chat.command.infrastructure.adapters.HuggingFaceApiAdapter.EmotionAnalysisResponse;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 /** HuggingFace API 실제 연결 통합 테스트 */
-// @Disabled
+@Disabled
 @SpringBootTest
 public class HuggingFaceApiAdapterIntegrationTest {
 

--- a/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/chat/command/infrastructure/adapters/HuggingFaceApiAdapterTest.java
+++ b/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/chat/command/infrastructure/adapters/HuggingFaceApiAdapterTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -38,7 +39,8 @@ class HuggingFaceApiAdapterTest {
 
   @Mock private RestTemplate restTemplate;
 
-  @Spy private ObjectMapper objectMapper = new ObjectMapper();
+  @Spy
+  @Qualifier("restTemplateObjectMapper") private ObjectMapper objectMapper = new ObjectMapper();
 
   private HuggingFaceApiAdapter huggingFaceApiAdapter;
 

--- a/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/chat/command/infrastructure/repository/MongoChatMessageRepositoryIntegrationTest.java
+++ b/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/chat/command/infrastructure/repository/MongoChatMessageRepositoryIntegrationTest.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +25,7 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
 
 /** MongoDB 실제 연결 통합 테스트 @Disabled("실제 DB 연결이 필요한 테스트") */
-// @Disabled
+@Disabled
 @SpringBootTest
 public class MongoChatMessageRepositoryIntegrationTest {
 


### PR DESCRIPTION
JACKSON config(localtime 직렬화 몽고DB 등에 필요)
RestTemplate(HTTP 통신용) objectMapper Qualifier 지정 및 이름 변경하여 @primary 외에 명시적인 구분자 추가

## 🔘Part

- [ ] FE
- [x] BE

## 📓이슈 번호

- close

## 🔎 작업 내용

-
-
